### PR TITLE
Fix Generator command

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -56,9 +56,12 @@ class MakeCommand extends GeneratorCommand
      */
     protected function replaceNamespace(&$stub, $name)
     {
+        // Get Root Namespace.
+        $rootNamespace = $this->laravel->getNamespace();
+
         $stub = str_replace(
             ['DummyNamespace', 'DummyRootNamespace', 'DummyTargetModel'],
-            [$this->getNamespace($name), $this->rootNamespace(), $this->option('model')],
+            [$this->getNamespace($name), $rootNamespace, $this->option('model')],
             $stub
         );
 


### PR DESCRIPTION
For laravel versions older than 5.4
we do not have the rootNamespace() method
hence we must use the class attribute to
get the rootNamspace.